### PR TITLE
Add Django 6.1 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # Derived from requires-python (>=3.10) + Django constraint (>=5.2) and the
-        # upstream-supported Django series (5.2 LTS, 6.0) as of 2026-07.
+        # upstream-supported Django series (5.2 LTS, 6.0, 6.1) as of 2026-08.
         # Recompute this list on every re-run — do not hardcode long-term.
         include:
           # Django 5.2 LTS (Python 3.10-3.14)
@@ -33,6 +33,10 @@ jobs:
           - { python-version: "3.12", django-version: "6.0" }
           - { python-version: "3.13", django-version: "6.0" }
           - { python-version: "3.14", django-version: "6.0" }
+          # Django 6.1 (Python 3.12+)
+          - { python-version: "3.12", django-version: "6.1" }
+          - { python-version: "3.13", django-version: "6.1" }
+          - { python-version: "3.14", django-version: "6.1" }
 
     services:
       postgres:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
           uv pip install "django~=${{ matrix.django-version }}.0"
 
       - name: Run tests
-        run: uv run pytest
+        run: uv run --no-sync pytest
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ djorm-ext-filtered-contenttypes
 [![Tests](https://github.com/mpasternak/djorm-ext-filtered-contenttypes/actions/workflows/tests.yml/badge.svg)](https://github.com/mpasternak/djorm-ext-filtered-contenttypes/actions/workflows/tests.yml)
 [![PyPI Version](https://img.shields.io/pypi/v/djorm-ext-filtered-contenttypes)](https://pypi.org/project/djorm-ext-filtered-contenttypes/)
 [![Python Version](https://img.shields.io/pypi/pyversions/djorm-ext-filtered-contenttypes)](https://pypi.org/project/djorm-ext-filtered-contenttypes/)
-![Django](https://img.shields.io/badge/django-5.2%20%7C%206.0-blue)
+![Django](https://img.shields.io/badge/django-5.2%20%7C%206.0%20%7C%206.1-blue)
 [![License](https://img.shields.io/github/license/mpasternak/djorm-ext-filtered-contenttypes)](LICENSE)
 
 A GenericForeignKey, that can be filtered & indexed server-side using subqueries.
 
-Supports Django 5.2 LTS and 6.0 on Python 3.10–3.14. (Previously: Django 1.7–1.11 on Python 2.7/3.5/3.6.)
+Supports Django 5.2 LTS, 6.0 and 6.1 on Python 3.10–3.14. (Previously: Django 1.7–1.11 on Python 2.7/3.5/3.6.)
 
 Created for and tested with PostgreSQL - feel free to submit patches for other databases.
 
@@ -39,7 +39,7 @@ Using pip:
 pip install djorm-ext-filtered-contenttypes
 ```
 
-Requires Python 3.10+ and Django 5.2 or 6.0. PostgreSQL is required — the filtering relies on PostgreSQL-specific compound-column subqueries.
+Requires Python 3.10+ and Django 5.2, 6.0 or 6.1. PostgreSQL is required — the filtering relies on PostgreSQL-specific compound-column subqueries.
 
 
 Supported versions
@@ -51,6 +51,7 @@ Every combination below is exercised in CI:
 |---------|:----:|:----:|:----:|:----:|:----:|
 | 5.2 LTS |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
 | 6.0     |  —   |  —   |  ✓   |  ✓   |  ✓   |
+| 6.1     |  —   |  —   |  ✓   |  ✓   |  ✓   |
 
 
 Introduction
@@ -172,6 +173,15 @@ Now, let's play:
 
 Changelog
 ---------
+
+**Unreleased**
+
+- Added support for Django 6.1 (Python 3.12+), tested in CI alongside 5.2 LTS and 6.0.
+- Fixed lookup SQL generation for Django 6.1, which now quotes generated table aliases
+  (`"V0"` instead of `V0`). The compound `(content_type_id, object_id)` left-hand side is
+  now quoted through the compiler instead of being interpolated bare, which previously made
+  PostgreSQL fail with `missing FROM-clause entry for table "v0"` when a filtered queryset
+  was used as the right-hand side of `item__in_raw`.
 
 **0.5.1**
 

--- a/filtered_contenttypes/fields.py
+++ b/filtered_contenttypes/fields.py
@@ -95,10 +95,21 @@ class FilteredGenericForeignKeyLookup(Lookup):
         return (",".join(["%s"]*len(value)),ret)
 
     def as_sql(self, qn, connection):
+        # Quote the table/alias exactly the way the compiler does for every
+        # other column reference in this query. Django 6.1 started quoting
+        # generated table aliases in the FROM clause ("V0" instead of V0), and
+        # PostgreSQL folds unquoted identifiers to lower case — so hardcoding
+        # the bare alias here produced references to a non-existent "v0".
+        #
+        # SQLCompiler.quote_name() exists since Django 6.1; on 5.2/6.0 the
+        # equivalent (and only) helper is quote_name_unless_alias(), which is
+        # deprecated in 6.1 and removed in 7.0.
+        quote_name = getattr(qn, "quote_name", None) or qn.quote_name_unless_alias
+        alias = quote_name(self.lhs.alias)
         lhs = '(%s."%s", %s."%s")' % (
-            self.lhs.alias,
+            alias,
             self.lhs.output_field.ct_field + "_id",
-            self.lhs.alias,
+            alias,
             self.lhs.output_field.fk_field)
 
         rhs, rhs_params = self.get_db_prep_lookup(self.rhs, connection)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Adds Django 6.1 (released 2026-08-05) to the supported/tested version matrix, and fixes one real incompatibility found while doing so.

## Changed places

- **`.github/workflows/tests.yml`** — three new matrix entries for Django 6.1 on Python 3.12, 3.13 and 3.14, mirroring the existing 6.0 rows. Django 6.1 requires **Python >= 3.12**, so 3.10/3.11 are deliberately not paired with it. The matrix is an `include:` list (no `exclude:` needed). Install method is unchanged — `django~=6.1.0` resolves to `>=6.1.0,<6.2`.
- **`pyproject.toml`** — added the `Framework :: Django :: 6.1` classifier. The dependency pin is `django>=5.2` with no upper bound, so nothing had to be loosened.
- **`README.md`** — badge, intro line, install requirement line, the "Supported versions" table, and a changelog entry.
- **`filtered_contenttypes/fields.py`** — actual code fix, see below.

## Real Django 6.1 incompatibility (fixed)

Django 6.1 now **quotes generated table aliases** in the `FROM` clause: `FROM "tests_promoitems" "V0"` where 6.0 emitted `FROM "tests_promoitems" V0`. Relatedly, `SQLCompiler.quote_name_unless_alias()` is deprecated in 6.1 (`RemovedInDjango70Warning`) in favour of a new `SQLCompiler.quote_name()` that always quotes.

`FilteredGenericForeignKeyLookup.as_sql()` built the compound left-hand side by interpolating the bare alias:

```python
lhs = '(%s."%s", %s."%s")' % (self.lhs.alias, ...)
```

PostgreSQL folds unquoted identifiers to lower case, so `V0."content_type_id"` resolved to `v0` while the `FROM` clause declared `"V0"`. Under Django 6.1 this made `test_in_raw_custom_sql_query` fail with:

```
django.db.utils.ProgrammingError: missing FROM-clause entry for table "v0"
```

The alias is now quoted through the compiler, matching whatever Django itself does for every other column reference in the same query — `compiler.quote_name()` on 6.1+, falling back to `quote_name_unless_alias()` on 5.2/6.0 where it is the only helper that exists. This also avoids emitting the 6.1 deprecation warning.

## Verification

Full test suite run locally against a PostgreSQL 17 container on Python 3.13:

| Django | Result |
|--------|--------|
| 5.2.17 | 7 passed |
| 6.0.8  | 7 passed |
| 6.1    | 7 passed, 0 warnings |

No prerelease-installing job exists in this repo, so nothing to retarget there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)